### PR TITLE
Setup CI pipeline using GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,47 @@
+name: CI Pipeline
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Run tests
+      run: |
+        python -m unittest discover -s tests
+
+    - name: Run pylint
+      run: |
+        pylint src
+
+    - name: Run flake8
+      run: |
+        flake8 src
+
+    - name: Run mypy
+      run: |
+        mypy src
+
+    - name: Run bandit
+      run: |
+        bandit -r src

--- a/README.md
+++ b/README.md
@@ -19,6 +19,20 @@ To run code analysis with pylint, flake8, and SonarQube, follow these steps:
 3. Run flake8: `flake8 <your_python_file.py>`
 4. Run SonarQube analysis: `sonar-scanner`
 
+## Continuous Integration (CI) Pipeline
+This project uses GitHub Actions to set up a Continuous Integration (CI) pipeline. The CI pipeline is configured to automatically run tests and ensure code quality on every push or pull request.
+
+### CI Pipeline Setup
+1. Create a new directory `.github/workflows` in the root of your repository if it doesn't already exist.
+2. Inside the `.github/workflows` directory, create a new file named `ci.yml`.
+3. Define the workflow in the `ci.yml` file to run your tests and code quality checks.
+
+### CI Pipeline Usage
+The CI pipeline is triggered on specific events such as `push` or `pull_request`. It includes the following steps:
+1. Set up the Python environment using `actions/setup-python`.
+2. Install dependencies using `pip install -r requirements.txt`.
+3. Run tests and code quality checks.
+
 ## Contributing
 Contributions are welcome! Feel free to submit issues or pull requests.
 


### PR DESCRIPTION
Add a GitHub Actions workflow to set up a Continuous Integration (CI) pipeline.

* **README.md**
  - Add a section about the CI pipeline setup and usage.
  - Mention the `ci.yml` file in the `.github/workflows` directory.

* **.github/workflows/ci.yml**
  - Define the name of the workflow as "CI Pipeline".
  - Specify trigger events for `push` and `pull_request` on the `main` branch.
  - Define jobs to set up the Python environment, install dependencies, run tests, and perform code quality checks using pylint, flake8, mypy, and bandit.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/akaday/AI_Code_Evolution_Agent/pull/3?shareId=582bbda9-dc15-4a35-acb1-e3477de7a788).